### PR TITLE
Adds CONTRIBUTING and cleans up README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,6 @@ Closes #
 - [ ] todo: 
 
 ## Checklist
-## Checklist
 - [x] The following are complete:
     - Added or revised tests if appropriate.
     - If new packages are installed, `requirements.txt` is updated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,175 @@
+This page describes how to contribute to the `ml4c3` repo.
+
+## Table of Contents
+1. [:octocat: Workflow](#octocat-workflow)
+1. [:warning: Issues](#warning-issues)
+1. [:evergreen_tree: Branches](#evergreen_tree-branches)
+1. [:speech_balloon: Commit messages](#speech_balloon-commit-messages)
+1. [:white_check_mark: Pre-commit hooks](#white_check_mark-pre-commit-hooks)
+1. [:rocket: Pull requests](#rocket-pull-requests)
+1. [:construction: Code reviews](#construction-code-reviews)
+1. [:globe_with_meridians: Wiki](#globe_with_meridians-wiki)
+
+## :octocat: Workflow
+You have an idea for a new way to visualize data. Or, you identified a bug in some machine learning infrastructure. Or, you want to speed up tensorization with a new Python package.
+
+1. Open an issue (or, take ownership of an existing issue).
+    - When you begin working on an issue, move it to `in progress` on the board.
+1. Check out a branch:
+    ```bash
+    git commit -B er-fix-tensorflow-error
+    ```
+1. Commit changes early and often!
+1. When the code is ready for review, submit a PR. Your goal is to merge your work into `master`.
+
+The rest of the documentation describes each step in more detail.
+
+## :warning: Issues
+Every task has an issue, and each issue has 1+ labels.
+
+New issues are created with our [issue templates](.github/ISSUE_TEMPLATE): 1) new feature request or enhancement, 2) data or modeling task, 3) question ,or 4) bug report.
+
+Good issues are clearly written and small enough to be addressed in a few days. Several small tasks can be bundled into one issue.
+
+Issues (aside from questions) should have one person who owns responsibility for completion.
+
+We prefer to close issues via pull request (PR; see below).
+
+We organize issues and PRs by project using [boards](https://github.com/orgs/aguirre-lab/projects).
+
+Boards are incredibly powerful because it allows anyone on the team to quickly understand what everyone else is working on, identify blockers, and assess progress.
+
+New issues go to the `To do (backlog)` column.
+
+If a new issue is a priority, it is moved to the `To do (current sprint)` column and addressed that week.
+
+Issues that are actively being worked on are moved to the `In progress (issues)` column.
+
+Issues do not go in `In review (PRs)` column. Only PRs go there.
+
+## :evergreen_tree: Branches
+When you start to work on an issue, create a new branch and work on it until the code is ready to be merged with the master.
+
+Name your branch with your initials, a description related to the issue, and dashes between words:
+```bash
+$ git checkout -b er-fix-grid-ecg-plot
+$ git push -u origin er-fix-grid-ecg-plot
+```
+
+## :speech_balloon: Commit messages
+1. Use the present tense ("Add feature" not "Added feature")
+1. Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+1. Limit the first line to 72 characters or less
+1. Reference issues and pull requests liberally after the first line
+
+## :white_check_mark: Pre-commit hooks
+We use `pre-commit` to automate a linting pipeline to run each time you call `git commit`.
+
+`pre-commit` hooks must all pass (or the user must ignore them via the `-n` flag) for
+files to be committed.
+
+### Linting
+Linting the code means keeping the code readable and in a good format (Similar to
+what [PEP8](https://www.python.org/dev/peps/pep-0008/) dictates). To do that,
+a pipeline has been configured to run formatting tests. This pipeline will
+check your code for formatting mistakes. It will also reformat some of your
+code automatically so that you don't have to do it yourself, but some
+modifications will still need to be done manually.
+
+The following tests compose the linting pipeline:
+
+| Test name                       | Short description                                                           |
+|---------------------------------|-----------------------------------------------------------------------------|
+| check-executables-have-shebangs | Ensures that (non-binary) executables have a shebang.                       |
+| check-symlinks                  | Checks for symlinks which do not point to anything.                         |
+| check-toml                      | This hook checks xml files for parseable syntax.                            |
+| check-yaml                      | This hook checks yaml files for parseable syntax.                           |
+| debug-statements                | Check for debugger imports and py37+ `breakpoint()` calls in python source. |
+| end-of-file-fixer               | Ensures that a file is either empty, or ends with one newline.              |
+| mixed-line-ending               | Replaces ; endings bu \n                                                    |
+| name-tests-test                 | This verifies that test files are named correctly                           |
+| no-commit-to-branch             | Don't commit to branch (master)                                             |
+| trailing-whitespace             | This hook trims trailing whitespace.                                        |
+| python-use-type-annotations     | Enforce that python3.6+ type annotations are used instead of type comments  |
+| python-no-log-warn              | A quick check for the deprecated `.warn()` method of python loggers         |
+| rst-backticks                   | Detect common mistake of using single backticks when writing rst            |
+| isort                           | Check and reorders imports                                                  |
+| seed-isort-config               | Automatic configuration for third party packages for isort                  |
+| black                           | Popular linter. Checks and reformats code                                   |
+| docformatter                    | Reformats docstrings                                                        |
+| pydocstyle                      | Checks docstrings' format                                                   |
+| markdownlint                    | Checks markdown syntax                                                      |
+| flake8                          | Popular linter. Checks the code more deeply than black                      |
+| pylint                          | Most popular linter and also the most strict                                |
+| mypy                            | Checks python's typing                                                      |
+| gitlint                         | Checks commit messages                                                      |
+
+This pipeline is called on every commit. However, if you want to pass a particular 
+test of the pipeline at any time, you can run
+
+```
+pre-commit run <name of the test>
+```
+
+### `pre-commit` hooks
+Normally, all tests should pass before you commit. However, sometimes
+tests are too strict or they ask for somethings that can't be made in
+a particular situation. Some tests may even contradict each other.
+
+If you find yourself in one of these situations, you can to skip a particular test run by doing:
+
+```
+$ SKIP=pylint git commit -m 'this is a special commit'
+```
+
+To skip multiple tests:
+```
+$ SKIP=pylint,flake8 git commit -m 'this is a special commit'
+```
+
+To skip all the tests (this should hardly ever happen):
+```
+$ git commit -m 'this is a very special commit' --no-verify
+```
+
+## :rocket: Pull requests
+To contribute code or documentation changes from your branch to the `master` branch in the repo, open a PR.
+
+Before you submit a PR, review these [best practices for participating in a code review](https://mtlynch.io/code-review-love/).
+
+New PRs follow our [template](.github/pull_request_template.md):
+- List the issues your PR closes. This auto-populates the "linked issues" section on the right nav bar.
+- Describe the major changes in bullet points.
+- Ensure you check all of the quality control boxes.
+
+Start your PR as a draft. When your PR is finalized and ready for review, convert it from a draft to a pull PR.
+
+Assign at least one reviewer.
+
+Reviewers approve PRs before code merges to `master`. Our team strives for a turnaround time of 24-48 hours. If a review is stale, remind the reviewer. If the review is too complex for this turnaround time, the PR is too large and should be divided into smaller PRs.
+
+When PRs are approved, all commits are "squash merged", e.g. combine all commits from the head branch into a single commit in the base branch. Also, the branch is automatically deleted.
+
+We encourage small and fast PRs that solve one or a few issues. They are easier to write, review, and merge. Hence, they are also less likely to introduce catastrophic bugs.
+
+## :construction: Code reviews
+Reviewing other's code, and having your code reviewed by others, is an important part of ensuring our code is excellent. It also helps us improve how we communicate ideas -- in code, in comments as a reviewer, and in responses to reviewer comments.
+
+Code reviewers focus on implementation and style that are not caught by debugging or `pre-commit` hooks:
+1. Are variables clearly named and self-explanatory? We avoid short names or acronyms that lack description.
+1. Are arguments type-hinted?
+1. Is code appropriately modularized? If code is repeated, should it be a function instead?
+1. Is code in the appropriate scope for that script? Should the function be somewhere else in the repo?
+1. Is the functionality performant? Is there a faster but not substantially more challenging implementation?
+
+The developer who submits the PR is responsible for code to run without errors, and to
+not break other functionality in the repo. Automated tests also help with this.
+
+To learn how to review code, you must spend some time with our group to understand our
+style. We recommend you look at the reviews from merged PRs to understand expectations.
+
+## :globe_with_meridians: Wiki
+`ml4c3` and all related data resources are documented in the repo's [wiki](https://github.com/aguirre-lab/ml4c3/wiki).
+
+Do not directly edit the `ml4c3` wiki! Instead, submit issues and PRs to the [wiki repo](https://github.com/aguirre-lab/ml4c3-wiki/).
+The `ml4c3` wiki is automatically updated from the `ml4c3-wiki` repo via Travis.

--- a/README.md
+++ b/README.md
@@ -1,228 +1,45 @@
-# Aguirre Lab - onboarding & workflow
+# Aguirre Lab handbook
+
+This documentation describes how our group operates, what resources we use, and how you access them.
+
+Before you go any further, read [`the missing semester of your CS education`](https://missing.csail.mit.edu) to learn the basics of the tools we use every day.
 
 ## Contents
-- [Stack](#stack)
 - [GitHub](#github)
-- [Wiki](#Wiki)
-- [Slack](#slack)
+- [Communication](#communication)
 - [Meetings](#meetings)
-- [Data](#data)
 - [Compute](#compute)
+- [Data](#data)
 - [MGH logistics](#mgh-logistics)
 - [Office space](#office-space)
-- [Roster](https://paper.dropbox.com/doc/aguirre-lab-roster-lGQvFINrQ1ZQ6A6GnMpkp)
-- [IRB coverage](https://paper.dropbox.com/doc/IRB-coverage--A7uo~yh4R0BWfUIVP3aAtb_MAg-ypV58gm96PA8WeNy09XLM)
+- [Roster (link to external doc)](https://paper.dropbox.com/doc/aguirre-lab-roster-lGQvFINrQ1ZQ6A6GnMpkp)
+- [IRB coverage (link to external doc)](https://paper.dropbox.com/doc/IRB-coverage--A7uo~yh4R0BWfUIVP3aAtb_MAg-ypV58gm96PA8WeNy09XLM)
 
-## Stack
-Read [`the missing semester of your CS education`](https://missing.csail.mit.edu) to learn basic proficiency with the tools we use every day.
+## GitHub
+As a data science group, we spend most of our time collaboratively writing code via GitHub.
+Here are some of our general practices:
+1. DO NOT SHARE DATA ON GITHUB!
+1. Code is stored and shared via GitHub. Do not share code via Dropbox, email, or any other mechanism.
+1. Our GitHub organization is [`https://github.com/aguirre-lab`](https://github.com/aguirre-lab).
+1. Our main repo is [`ml4c3`](https://github.com/aguirre-lab/ml4c3). You contribute to the team and your projects by submitting a PR that merges into `master`. 
+1. If you think your work is out of scope for `ml4c3`, discuss with the team. If the consensus is that the work is out of scope, open a new private repo in `aguirre-lab`.
+1. Repos are private. Open-sourcing requires a discussion with the PI and their collaborating PIs.
+1. Code is documented in each repo's `README` and/or wiki.
+1. We use the [BSD 3-clause license](https://choosealicense.com/licenses/bsd-3-clause/).
+1. Create branches, push commits, and submit PRs as early as possible.
 
-Our workstations and servers run Ubuntu.
+To learn about specifics of our workflow, and how to contribute to `ml4c3`, read [`CONTRIBUTING`](/contributing.md).
 
-We interact with our workstations and servers via the shell over `ssh`. [`iTerm2`](https://iterm2.com) is especially good for macOS. To manage sessions and panes, many of us use `tmux`. We do not use graphical remote desktop software.
-
-Our team develops and uses a data parsing, visualization, and modeling pipeline called [`ml4c3`](https://github.com/aguirre-lab/ml4c3). We use Docker to ensure identical development environments. Miniconda is also installed on every workstation (see [the docs](miniconda.md)).
-
-We manage code and projects in GitHub: version control, documentation, code review, issues, etc. *Data* is not stored on GitHub.
-
+## Communication
 Communication around tasks is primarily via GitHub. We do this to document shareable conversations, link discussions to code, and avoid interrupting "deep work". [Read more about why aysnchronous communication is good](https://blog.doist.com/asynchronous-communication/).
 
 Sometimes sychronous communication is good. We chat on Slack and meet on Zoom, but we minimize email. This excerpt from the above blog post explains why:
 
 > Don’t use email internally. While email can be used asynchronously, it also locks information inside people’s inboxes where no one else can find it. When people can’t find the information they need, collaboration becomes much less efficient.
 
-We use Dropbox to store results, smaller data sets, manuscripts, etc. [`Here is a guide`](dropbox.md) to setting up Dropbox on a Linux machine. Dropbox a) lets us share PHI, b) backs up files automatically, and c) syncs files across machines. Code is *not* stored on Dropbox; code is stored in GitHub.
-
-We schedule meetings on our MGH calendars (Outlook).
-
-## GitHub
-
-As a data science and software engineering group, we spend most of our time on GitHub.
-Here are some of our general practices:
-1. DO NOT SHARE PHI ON GITHUB!
-1. Code is stored and shared via GitHub. Do not store or share code via Dropbox, email, or any other mechanism.
-1. Our GitHub organization is [`https://github.com/aguirre-lab`](https://github.com/aguirre-lab).
-1. Our main repo is [`ml4c3`](https://github.com/aguirre-lab/ml4c3). Your work should almost always be an issue, branch, and eventually PR back into `ml4c3`. See _workflow_ below.
-1. If your work is truly out of scope for `ml4c3`, open a new private repo in `aguirre-lab`.
-1. Repos are private. Open-sourcing of code requires a discussion with the PI and their collaborating PIs.
-1. Code is documented in the repo `README` and/or a wiki.
-1. We use the [BSD 3-clause license](https://choosealicense.com/licenses/bsd-3-clause/).
-1. Create branches, push commits, and submit PRs as early as possible.
-
-### Workflow
-1. Open an issue. Or, if you are assigned an issue, move it from `backlog` or `to do` to `in progress`.
-1. Check out a branch.
-1. Commit changes early and often.
-1. When the code is ready to merge, submit a PR.
-
-Each step of the above workflow is described more below.
-
-### 1. Issues
-Every task has an issue, and each issue has 1+ labels.
-
-New issues are created with our [issue templates](.github/ISSUE_TEMPLATE): 1) new feature request or enhancement, 2) data or modeling task, 3) question ,or 4) bug report.
-
-Good issues are clearly written and small enough to be addressed in a few days. Several small tasks can be bundled into one issue.
-
-Issues (aside from questions) should have one person who owns responsibility for completion.
-
-We prefer to close issues via pull request (PR; see below).
-
-We organize issues and PRs by project using [boards](https://github.com/orgs/aguirre-lab/projects).
-
-Boards are incredibly powerful because it allows anyone on the team to quickly understand what everyone else is working on, identify blockers, and assess progress.
-
-New issues go to the `To do (backlog)` column.
-
-If a new issue is a priority, it is moved to the `To do (current sprint)` column and addressed that week.
-
-Issues that are actively being worked on are moved to the `In progress (issues)` column.
-
-Issues do not go in `In review (PRs)` column. Only PRs go there.
-
-### 2. Branches
-When you start to work on an issue, create a new branch and work on it until the code is ready to be merged with the master.
-
-Name your branch with your initials, a description related to the issue, and dashes between words:
-```bash
-$ git checkout -b er-fix-grid-ecg-plot
-$ git push -u origin er-fix-grid-ecg-plot
-```
-
-### 3. Commit messages
-Commit changes by adding the corresponding files and commit them. If you also want to see the changes on the repo, push them:
-```bash
-$ git add <file_1> <file2_> <file_n>
-$ git commit -m <message>
-$ git push 
-```
-We do not enforce strict commit message style, but try to follow good practices as 
-described in [this blog post](https://chris.beams.io/posts/git-commit/#capitalize). 
-Moreover, it is strongly encouraged to add the issue id at each commit message, so
-commits are tracked within the issue:
-```bash
-$ git commit -m <<message> Ref #<issue id>>
-```
-
-### 3b. Pre-commit hooks
-We use `pre-commit` to automate a linting pipeline to run each time you call `git commit`.
-
-`pre-commit` hooks must all pass (or the user must ignore them via the `-n` flag) for
-files to be committed.
-
-#### Linting
-Linting the code means keeping the code readable and in a good format (Similar to
-what [PEP8](https://www.python.org/dev/peps/pep-0008/) dictates). To do that,
-a pipeline has been configured to run formatting tests. This pipeline will
-check your code for formatting mistakes. It will also reformat some of your
-code automatically so that you don't have to do it yourself, but some
-modifications will still need to be done manually.
-
-The following tests compose the linting pipeline:
-
-| Test name                       | Short description                                                           |
-|---------------------------------|-----------------------------------------------------------------------------|
-| check-executables-have-shebangs | Ensures that (non-binary) executables have a shebang.                       |
-| check-symlinks                  | Checks for symlinks which do not point to anything.                         |
-| check-toml                      | This hook checks xml files for parseable syntax.                            |
-| check-yaml                      | This hook checks yaml files for parseable syntax.                           |
-| debug-statements                | Check for debugger imports and py37+ `breakpoint()` calls in python source. |
-| end-of-file-fixer               | Ensures that a file is either empty, or ends with one newline.              |
-| mixed-line-ending               | Replaces ; endings bu \n                                                    |
-| name-tests-test                 | This verifies that test files are named correctly                           |
-| no-commit-to-branch             | Don't commit to branch (master)                                             |
-| trailing-whitespace             | This hook trims trailing whitespace.                                        |
-| python-use-type-annotations     | Enforce that python3.6+ type annotations are used instead of type comments  |
-| python-no-log-warn              | A quick check for the deprecated `.warn()` method of python loggers         |
-| rst-backticks                   | Detect common mistake of using single backticks when writing rst            |
-| isort                           | Check and reorders imports                                                  |
-| seed-isort-config               | Automatic configuration for third party packages for isort                  |
-| black                           | Popular linter. Checks and reformats code                                   |
-| docformatter                    | Reformats docstrings                                                        |
-| pydocstyle                      | Checks docstrings' format                                                   |
-| markdownlint                    | Checks markdown syntax                                                      |
-| flake8                          | Popular linter. Checks the code more deeply than black                      |
-| pylint                          | Most popular linter and also the most strict                                |
-| mypy                            | Checks python's typing                                                      |
-| gitlint                         | Checks commit messages                                                      |
-
-This pipeline is called on every commit. However, if you want to pass a particular 
-test of the pipeline at any time, you can run
-
-```
-pre-commit run <name of the test>
-```
-
-#### Dealing with the hooks
-Normally, all tests should pass before you commit. However, sometimes
-tests are too strict or they ask for somethings that can't be made in
-a particular situation. Some tests may even contradict each other.
-
-If you find yourself in one of these situations, you can to skip a particular test run by doing:
-
-```
-$ SKIP=pylint git commit -m 'this is a special commit'
-```
-
-To skip multiple tests:
-```
-$ SKIP=pylint,flake8 git commit -m 'this is a special commit'
-```
-
-To skip all the tests (this should hardly ever happen):
-```
-$ git commit -m 'this is a very special commit' --no-verify
-```
-
-### 4. Pull requests (PRs)
-To contribute code or documentation changes from your branch to the `master` branch in the repo, open a PR.
-
-Before you submit a PR, review these [best practices for participating in a code review](https://mtlynch.io/code-review-love/).
-
-New PRs follow our [template](.github/pull_request_template.md):
-- List the issues your PR closes. This auto-populates the "linked issues" section on the right nav bar.
-- Describe the major changes in bullet points.
-- Ensure you check all of the quality control boxes.
-
-Start your PR as a draft. When your PR is finalized and ready for review, convert it from a draft to a pull PR.
-
-Assign at least one reviewer.
-
-Reviewers approve PRs before code merges to `master`. Our team strives for a turnaround time of 24-48 hours. If a review is stale, remind the reviewer. If the review is too complex for this turnaround time, the PR is too large and should be divided into smaller PRs.
-
-When PRs are approved, all commits are "squash merged", e.g. combine all commits from the head branch into a single commit in the base branch. Also, the branch is automatically deleted.
-
-We encourage small and fast PRs that solve one or a few issues. They are easier to write, review, and merge. Hence, they are also less likely to introduce catastrophic bugs.
-
-### Code reviews
-Reviewing other's code, and having your code reviewed by others, is an important part of ensuring our code is excellent. It also helps us improve how we communicate ideas -- in code, in comments as a reviewer, and in responses to reviewer comments.
-
-Code reviewers focus on implementation and style that are not caught by debugging or `pre-commit` hooks:
-1. Are variables clearly named and self-explanatory? We avoid short names or acronyms that lack description.
-1. Are arguments type-hinted?
-1. Is code appropriately modularized? If code is repeated, should it be a function instead?
-1. Is code in the appropriate scope for that script? Should the function be somewhere else in the repo?
-1. Is the functionality performant? Is there a faster but not substantially more challenging implementation?
-
-The developer who submits the PR is responsible for code to run without errors, and to
-not break other functionality in the repo. Automated tests also help with this.
-
-To learn how to review code, you must spend some time with our group to understand our
-style. We recommend you look at the reviews from merged PRs to understand expectations.
-
-## Wiki
-Our [Wiki](https://github.com/aguirre-lab/ml4c3/wiki) contains the documentation for 
-`ml4c3`, data sources, and more.
-
-**Do not directly edit the wiki in the `ml4c3` wiki!** Instead, submit issues and PRs 
-to our [wiki repo](https://github.com/aguirre-lab/ml4c3-wiki/). The `ml4c3` wiki is 
-automatically updated from the `master` branch of the wiki repo.
-
-## Slack
 Join [`aguirre-lab.slack.com`](aguirre-lab.slack.com) with your MGH email.
 
-Slack is for conversation and notifications from GitHub.
-
-DO NOT SHARE PHI VIA SLACK.
+DO NOT SHARE PHI VIA SLACK!
 
 ## Meetings
 
@@ -230,7 +47,12 @@ Every meeting has (1) an MGH calendar invite, and (2) a Zoom link.
 The calendar event is ground truth.
 
 ### Standup
-Our engineering and data science team meets for 15m twice a week to share progress and blockers.
+Our technical team meets for a 15 min standup twice a week in front of the `ml4c3` project board.
+
+Each team member shares:
+1. What did I accomplish since the prior standup?
+1. What am I working on now?
+1. What is blocking me? What do I need help with?
 
 ### Group meeting schedule
 We meet weekly. A group member presents a research talk, paper, or method.
@@ -260,31 +82,14 @@ We meet weekly. A group member presents a research talk, paper, or method.
 | 2021 Apr 19 | Raimon  |
 ```
 
-## Data
-Data live in several places, all of which comply with MGH data security protocols:
-1. `mad3` and/or `landmark4`: MGB archival storage servers
-1. Workstations (see compute)
-1. Dropbox
-
-### Dropbox
-PHI may be stored on Dropbox, but we prefer to store data on our MGH workstations.
-
-Request a Dropbox account at https://rc.partners.org/kb/article/2750.
-
-If you sync your Dropbox account to your local machine, it must be in compliance with MGH policies, encrypted, etc.
-
-Do not store code on Dropbox. Code belongs on GitHub.
-
-Instructions for installing and configuring dropbox on our linux workstations is documnted here: [`dropbox instructions`](/dropbox.md)
-
 ## Compute
+Our workstations and servers run Ubuntu.
+
+We remotely access our workstations and servers via VPN and `ssh`. [`iTerm2`](https://iterm2.com) is especially good for macOS. To manage sessions and panes, many of us use `tmux`. We do not use graphical remote desktop software.
+
 Our compute inventory is at this [Dropbox Paper link](https://paper.dropbox.com/doc/aguirre-lab-pc-inventory--A7v~CM2jXCa06LGcCwmufIwZAg-miOikxSGYPyo6GkP8Zv5Y).
 
-We remotely access our workstations via VPN and SSH.
-
-We recommend you use a Mac or Linux machine and a terminal.
-
-ERISOne is the MGB research computing cluster. We do not usually use it, but have documented how to set it up for a data science workflow: [`erisone documentation`](/erisone.md)
+ERISOne is the MGB research computing cluster. We do not usually use it, but have [documented how to set up a data science workflow](/erisone.md).
 
 ### Workstation benchmarking tests
 Test and log your workstation's RAM, CPU, and GPU usage, power consumption, and heat load.
@@ -312,6 +117,25 @@ To run the benchmark tests:
 
 3. Results of GPU, CPU and RAM usage, thermal load, and power consumption will be logged in `./workstation_benchmarking_tests/result_logs`.
 
+## Data
+Data live in several places, all of which comply with MGH data security protocols:
+1. `mad3` and/or `landmark4`: MGB archival storage servers
+1. Workstations (see compute)
+1. Dropbox
+
+### Dropbox
+We use Dropbox to store results, smaller data sets, manuscripts, etc.
+
+Dropbox a) lets us share PHI, b) backs up files automatically, and c) syncs files across machines.
+
+PHI may be stored on Dropbox, but we prefer to store data on our MGH workstations.
+
+Request a Dropbox account at https://rc.partners.org/kb/article/2750.
+
+If you sync your Dropbox account to your local machine, it must be in compliance with MGH policies, encrypted, etc.
+
+Instructions for installing and configuring dropbox on our linux workstations is documnted here: [`dropbox instructions`](/dropbox.md)
+
 ## MGH logistics
 1. Request VPN access
     1. You need to log in to the Partners VPN if you SSH to a Partners machine, query the EDW, etc.. Request access at https://rc.partners.org/kb/article/2894
@@ -333,7 +157,7 @@ To run the benchmark tests:
 1. Request access to Electronic Data Warehouse (EDW), the MGH database for medical record data, via https://enterpriseanalytics.partners.org/Access/
 
 ## Office space
-_Not relevant now since we work from home due to COVID-19_
+_We currently work remotely due to COVID-19_
 
 - [Simches 3](https://goo.gl/maps/ZRyEoxg1nNSkUBe87)
     - Aaron's office


### PR DESCRIPTION
## Changelog
- [x] Adds `CONTRIBUTING` page to describe to users how to contribute to `ml4c3`
- [x] Cleans up Handbook in main `README`

## Checklist
- [x] The following are complete:
    - Added or revised tests if appropriate.
    - If new packages are installed, `requirements.txt` is updated.
    - If documentation should be updated, a new issue was made in `ml4c3-wiki`.
    - The PR name describes its content and does not contain "Ref #".
    - The PR does not add PHI.
